### PR TITLE
add other code pipeline states

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,10 @@ function generateRequestDetails(event, url) {
         color = "warning";
         text += "was canceled.";
     }
+    else if (pipelineState == 'SUPERSEDED') {
+        color = "warning";
+        text += "was *superseded*."
+    }
     else if (pipelineState == 'RESUMED') {
         color = "#888888";
         text += "has resumed.";

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,10 @@ function generateRequestDetails(event, url) {
         color = "danger";
         text += "has *failed*.";
     }
+    else if (pipelineState == 'CANCELED') {
+        color = "warning";
+        text += "was canceled.";
+    }
     else if (pipelineState == 'RESUMED') {
         color = "#888888";
         text += "has resumed.";

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,10 @@ function generateRequestDetails(event, url) {
         color = "danger";
         text += "has *failed*.";
     }
+    else if (pipelineState == 'RESUMED') {
+        color = "#888888";
+        text += "has resumed.";
+    }
     else {
         color = "warning";
         text += "has " + pipelineState + " (This is an unknown state to the Slack notifier.)";


### PR DESCRIPTION
Adds resumed, canceled and superseded from the [list of code pipeline states](https://docs.aws.amazon.com/codepipeline/latest/userguide/detect-state-changes-cloudwatch-events.html) to the list the notifier is aware of.